### PR TITLE
Remove '--exports' option. Make exports file referenced from declarations file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The *Generate* method takes on input generator options (described in details bel
 with both items containing generated TypeScript. The first item contains generated declarations, while the second 
 contains exported code. 
 
-**NOTE:** Specifiying a specific assembly to scan is not suported, since the SignalR DefaultHubManager 
+**NOTE:** Specifiying a specific assembly to scan is not supported, since the SignalR DefaultHubManager 
 is used which looks up for Hub implementations in all loaded assemblies.
 
 #### TypeScriptGeneratorOptions
@@ -110,7 +110,7 @@ type declaration for nullable members. The default value is **false**.
 
 This option shall only be used when generated script is expected to be compiled
 with TypeScript 2.0 compiler using the *strictNullChecks* compiler option. In such case types of nullable members are 
-generated as *union* types, containing primary type, plus *null* type. All the *Nullable<>* and reference* types are 
+generated as *union* types, containing primary type, plus *null* type. All the *Nullable<>* and reference types are 
 generated as nullable (see also the option *NotNullableTypeDiscovery* below).
  
 Example C# code: 
@@ -138,9 +138,9 @@ When generated using *GenerateStrictTypes*=**true**::
 Identifies the method used to discover members that should not be declared as nullable, where otherwise they would be.
 This option is only applicable if the *GenerateStrictTypes* option is set to **true**. Otherwise, it is ignored.
 
-- *NotNullableTypeDiscovery.None* - use default approach (All *Nullable<>* and reference* types generated as nullable).
+- *NotNullableTypeDiscovery.None* - use default approach (All *Nullable<>* and reference types generated as nullable).
 - *NotNullableTypeDiscovery.UseRequiredAttribute* - treat members attrobiuted with 
-  *System.ComponentModel.DataAnnotations.RequiredAttribute* as not=-nullable.
+  *System.ComponentModel.DataAnnotations.RequiredAttribute* as non-nullable.
 
 Example C# code: 
 
@@ -180,8 +180,7 @@ The long name must be prepended by double hyphen ('*--*'). Below is the list of 
 | Option                      | Description |
 |-----------------------------|-----------------------------------------------------------------|
 | -a, --assembly              | **Required**. The path to the assembly (.dll/.exe) |
-| -o, --output                | The path to the generated file containing declarations code. If this is empty, the output file name is written to stdout. If it ends with directory separator, the path is treated as directory and the output file name is generated from supplied assembly file name and written to the folder specified by output path. |
-| -e, --exports               | The path to the generated file containing exported code. If this is empty, name is generated from the output file. Ignored if 'output' value not specified.")]
+| -o, --output                | The path to the generated file containing declarations code. If this is empty, the output file name is written to stdout. If it ends with directory separator, the path is treated as directory and the output file name is generated from supplied assembly file name and written to the folder specified by output path. Exports file name is always derived from the declarations file. |
 | -r, --references            | Optional. List of reference file paths, delimited by semicolon. The **"/// \<reference\/\>** instruction is added for each file. |
 | -p, --optionalMembers       | Default: *None*. Specifies method to discover members treated as optional: *None* - don't generate optional members; *DataMemberAttribute* - use [DataMember(IsRequired)] attribute. |
 | -s, --strictTypes           | Default: *False*. If true, union definitions with *null* are generated for nullable types. |
@@ -190,11 +189,13 @@ The long name must be prepended by double hyphen ('*--*'). Below is the list of 
 
 If the output file is not specified the result is written to standard out.
 
+**NOTE:** Exports file will be automatically added as *reference* in decalrations file.
+
 #### Usage examples:
 
 For brevity, executable name used in examples is *generate.exe*.
 
-    generate.exe -a "c:\myapp\hubs.dll" -o "c:\temp\myapp.hubs.d.ts" -e "c:\temp\myapp.hubs.exports.ts"
+    generate.exe -a "c:\myapp\hubs.dll" -o "c:\temp\myapp.hubs.d.ts"
 
 Generates declarations and exports content from the specified assembly into *myapp.hubs.d.ts* and 
 *myapp.hubs.exports.ts* files, respectively, in the "c:\temp\" directory. Default options will be used.
@@ -204,11 +205,13 @@ Generates declarations and exports content from the specified assembly into *mya
 The output path ending with directory separator will cause output file generated from the input assembly name.
 Declarations and exports will be written to *hubs.d.ts* and *hubs.exports.ts*, in the *c:\\temp\\* directory.
 
-    generate.exe -a "c:\myapp\hubs.dll" -o "c:\temp\myapp_hubs.d.ts"
+    generate.exe -a "c:\myapp\hubs.dll" -o "c:\temp\" -p DataMemberAttribute  -s -n RequiredAttribute -r "../signalr/index.d.ts;../jquery/index.d.ts"
 
-The declarations output path specifies file name, but exports file is missing; in this case, exports file anem will be derived
-from the declarations file. Declarations and exports created in *myapp_hubs.d.ts* and *myapp_hubs.exports.ts* files,
-in the *c:\temp\* directory.
+Declarations and exports file names are derived from input assembly file name. Output scripts will contains two 
+reference instructions. Interface members will be generated as optional depending on the *[DataMemberAttribute]* 
+applied to data contract properties. Reference and *Nullable<>* types will be generated as union types, explicitly 
+including *null* type except for interface members having *[Required]* attribute.
+
  
 **# ONLY COMBATIBLE WITH SIGNALR VERSIONS AT 2.2.1.0 OR EARLIER #**
 

--- a/src/Signalr.Hubs.TypeScriptGenerator.Console.Tests/CommandLineOptionsTests.cs
+++ b/src/Signalr.Hubs.TypeScriptGenerator.Console.Tests/CommandLineOptionsTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using GeniusSports.Signalr.Hubs.TypeScriptGenerator.Console;
+﻿using GeniusSports.Signalr.Hubs.TypeScriptGenerator.Console;
 using NUnit.Framework;
 
 namespace Signalr.Hubs.TypeScriptGenerator.Console.Tests
@@ -22,85 +17,52 @@ namespace Signalr.Hubs.TypeScriptGenerator.Console.Tests
         }
 
         [Test]
-        [TestCase(null, null)]
-        [TestCase(null, "")]
-        [TestCase(null, " ")]
-        [TestCase("", null)]
-        [TestCase("", "")]
-        [TestCase("", " ")]
-        [TestCase(" ", null)]
-        [TestCase(" ", "")]
-        [TestCase(" ", " ")]
-        public void AdjustOutputPaths_WhenOutputIsEmpty_ThenResetsBothPathsToNull(string output, string exports)
+        [TestCase(null)]
+        [TestCase("")]
+        public void GetOutputPath_WhenOutputIsNullOrEmpty_ThenReturnsNullOrEmpty(string output)
         {
             // Arrange
             var sut = GetSUT();
             sut.Output = output;
-            sut.Exports = exports;
 
             // Act
-            sut.AdjustOutputPaths();
+            var outputPath = sut.GetOutputPath();
 
             // Assert
-            Assert.IsNull(sut.Output);
-            Assert.IsNull(sut.Exports);
+            Assert.That(outputPath, Is.EqualTo(output));
         }
 
         [Test]
-        public void AdjustOutputPaths_WhenPathsAreSpecified_DoesNotAlter()
+        public void GetOutputPath_WhenOutputIsNotDirectory_ReturnsTheSuppliedValue()
         {
             // Arrange
             var sut = GetSUT();
             var suppliedOutput = "supplied output";
-            var suppliedExports = "supplied exports";
             sut.Output = suppliedOutput;
-            sut.Exports = suppliedExports;
 
             // Act
-            sut.AdjustOutputPaths();
+            var outputPath = sut.GetOutputPath();
 
             // Assert
-            Assert.That(sut.Output, Is.EqualTo(suppliedOutput));
-            Assert.That(sut.Exports, Is.EqualTo(suppliedExports));
+            Assert.That(outputPath, Is.EqualTo(suppliedOutput));
         }
 
         [Test]
-        [TestCase(@".\", @".\assembly.d.ts", @".\assembly.exports.ts")]
-        [TestCase(@"\", @"\assembly.d.ts", @"\assembly.exports.ts")]
-        [TestCase(@"c:\ts\", @"c:\ts\assembly.d.ts", @"c:\ts\assembly.exports.ts")]
-        public void AdjustOutputPaths_WhenOutputIsDirectory_ThenGeneratesOutputPathFromAssembly(
-            string suppliedOutput, string expectedOutput, string expectedExports)
+        [TestCase(@".\", @".\assembly.d.ts")]
+        [TestCase(@"\", @"\assembly.d.ts")]
+        [TestCase(@"c:\ts\", @"c:\ts\assembly.d.ts")]
+        public void GetOutputPath_WhenOutputIsDirectory_ThenGeneratesOutputPathFromAssembly(
+            string suppliedOutput, string expectedOutput)
         {
             // Arrange
             var sut = GetSUT();
             sut.Output = suppliedOutput;
 
             // Act
-            sut.AdjustOutputPaths();
+            var outputPath = sut.GetOutputPath();
 
             // Assert
-            Assert.That(sut.Output, Is.EqualTo(expectedOutput));
-            Assert.That(sut.Exports, Is.EqualTo(expectedExports));
+            Assert.That(outputPath, Is.EqualTo(expectedOutput));
         }
-
-        [Test]
-        [TestCase(@"c:\ts\assembly.d.ts", @"c:\ts\assembly.exports.ts")]
-        [TestCase(@"c:\ts\assembly.ts", @"c:\ts\assembly.exports.ts")]
-        [TestCase(@"assembly.txt", @"assembly.exports.txt")]
-        [TestCase(@"assembly", @"assembly.exports")]
-        public void AdjustOutputPaths_WhenOutputIsDirectoryAndExportsIsEmpty_GeneratesExportsFromSuppliedOutput(
-            string suppliedOutput, string expectedExports)
-        {
-            // Arrange
-            var sut = GetSUT();
-            sut.Output = suppliedOutput;
-
-            // Act
-            sut.AdjustOutputPaths();
-
-            // Assert
-            Assert.That(sut.Exports, Is.EqualTo(expectedExports));
-        }
-
     }
 }

--- a/src/Signalr.Hubs.TypeScriptGenerator.Console/CommandLineOptions.cs
+++ b/src/Signalr.Hubs.TypeScriptGenerator.Console/CommandLineOptions.cs
@@ -13,9 +13,6 @@ namespace GeniusSports.Signalr.Hubs.TypeScriptGenerator.Console
 		[Option('o', "output", HelpText = "The path to the file to generate. If this is empty, the output is written to stdout.")]
 		public string Output { get; set; }
 
-		[Option('e', "exports", HelpText = "The path to the generated file containing exported code. If this is empty, name is generated from the output file.")]
-		public string Exports { get; set; }
-
 		[Option('r', "references", HelpText = "Optional. List of file paths, delimited by semicolon to be added as the <reference/> instruction.", Required = false)]
 		public string References { get; set; }
 
@@ -73,53 +70,18 @@ namespace GeniusSports.Signalr.Hubs.TypeScriptGenerator.Console
 			}
 		}
 
-		private const string DeclarationFileExtension = ".d.ts";
-		private const string TypescriptFileExtension = ".ts";
-		private const string ExportsSuffix = ".exports";
-
 		/// <summary>
-		/// Analyzes output paths specified in command line options, and adjusts/generates file path as needed.
+		/// Analyzes specified output path, and returnes adjusted/generateed output file path.
 		/// </summary>
-		public void AdjustOutputPaths()
+		public string GetOutputPath()
 		{
-			if (string.IsNullOrWhiteSpace(Output))
-			{
-				Output = null;
-				Exports = null;
-				return;
-			}
+			if (string.IsNullOrWhiteSpace(Output) || Output[Output.Length - 1] != Path.DirectorySeparatorChar)
+				return Output;
 
-			if (Output[Output.Length - 1] == Path.DirectorySeparatorChar)
-			{
-				// Treat output path as directory, and generate output file name
+			// Treat output path as directory, and generate output file name.
 
-				var assemblyFileName = Path.GetFileNameWithoutExtension(AssemblyPath);
-				Output = Path.Combine(Output, Path.ChangeExtension(assemblyFileName, DeclarationFileExtension));
-			}
-
-			if (string.IsNullOrWhiteSpace(Exports))
-			{
-				// Generate from output file.
-
-				foreach (var knownExtension in new[] { DeclarationFileExtension, TypescriptFileExtension } )
-				{
-					if (Output.EndsWith(knownExtension, StringComparison.InvariantCultureIgnoreCase))
-					{
-						Exports = string.Concat(Output.Substring(0, Output.Length - knownExtension.Length), ExportsSuffix, TypescriptFileExtension);
-						return;
-					}
-				}
-
-				var extension = Path.GetExtension(Output);
-				if (!string.IsNullOrEmpty(extension))
-				{
-					Exports = Path.ChangeExtension(Output, ExportsSuffix + extension);
-				}
-				else
-				{
-					Exports = Output + ExportsSuffix;
-				}
-			}
+			var assemblyFileName = Path.GetFileNameWithoutExtension(AssemblyPath);
+			return Path.Combine(Output, Path.ChangeExtension(assemblyFileName, ".d.ts"));
 		}
 	}
 }


### PR DESCRIPTION
Exports file path is always derived from specified output file.