### PR TITLE
Added support for nested types for DataContractInfo & IEnumerable

### DIFF
--- a/src/Signalr.Hubs.TypescriptGenerator/Helpers/HubHelper.cs
+++ b/src/Signalr.Hubs.TypescriptGenerator/Helpers/HubHelper.cs
@@ -106,7 +106,9 @@ namespace GeniusSports.Signalr.Hubs.TypeScriptGenerator.Helpers
 
 				string reasonDeprecated;
 				var isDeprecated = type.IsDeprecated(out reasonDeprecated);
-				list.Add(new DataContractInfo(typeHelper.GenericSpecificName(type, false), isDeprecated, reasonDeprecated, type.Namespace, bases, properties));
+                var fullNameWithDots = type.FullName.Replace("+", ".");
+                var moduleName = fullNameWithDots.Substring(0, fullNameWithDots.LastIndexOf('.'));
+				list.Add(new DataContractInfo(typeHelper.GenericSpecificName(type, false), isDeprecated, reasonDeprecated, moduleName, bases, properties));
 				typeHelper.DiscoverAdditionalTypes(type);
 			}
 

--- a/src/Signalr.Hubs.TypescriptGenerator/Helpers/TypeHelper.cs
+++ b/src/Signalr.Hubs.TypescriptGenerator/Helpers/TypeHelper.cs
@@ -119,7 +119,7 @@ namespace GeniusSports.Signalr.Hubs.TypeScriptGenerator.Helpers
 	                    return Nullable(nestedType, forceNotNullable);
 	                }
 
-	                if (typeof(List<>).IsAssignableFrom(type.GetGenericTypeDefinition()))
+	                if (typeof(IEnumerable<>).IsAssignableFrom(type.GetGenericTypeDefinition()))
 	                {
 	                    var elementType = GetTypeContractInfo(type.GetGenericArguments()[0]);
 	                    var arrayType = TypeInfo.Array(elementType);
@@ -160,7 +160,12 @@ namespace GeniusSports.Signalr.Hubs.TypeScriptGenerator.Helpers
 	                }
 	            }
 
-	            AddCustomType(type);
+                if (typeof(System.Collections.IEnumerable).IsAssignableFrom(type))
+                {
+                    return Nullable(TypeInfo.Array(TypeInfo.Any), forceNotNullable);
+                }
+
+                AddCustomType(type);
 	            return TypeInfo.Simple(GenericSpecificName(type, true));
 	        }
 	    }

--- a/src/Signalr.Hubs.TypescriptGenerator/Helpers/TypeHelper.cs
+++ b/src/Signalr.Hubs.TypescriptGenerator/Helpers/TypeHelper.cs
@@ -275,8 +275,9 @@ namespace GeniusSports.Signalr.Hubs.TypeScriptGenerator.Helpers
 
 		public string GenericSpecificName(Type type, bool referencing)
 		{
-			var name = (referencing ? type.FullName : type.Name).Split('`').First();
-			if (type.IsGenericType)
+            var name = (referencing ? type.FullName : type.Name).Split('`').First();
+            name = name.Replace("+", "."); // nested classes have + instead of .
+            if (type.IsGenericType)
 			{
 				name += "_" + string.Join("_", type.GenericTypeArguments.Select(a => GenericSpecificName(a, false))) + "_";
 			}


### PR DESCRIPTION
Current version does not handle nested types at all.
public Class Outer
{
  public Inner[] InnerObjects {get;set;}
  public Class Inner
  {
  }
}

will turn into:
declare module Namespace1 {
  interface Outer {
    InnerObjects : Namespace1.Outer+Inner[]      // <----------- notice the +
  }
  interface Inner {        // <------------- notice it's nested directly under Namespace1
  }
}

I've applied a simple fix to remedy this.